### PR TITLE
support polyfill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /composer.lock
 /config.php
+/set-env.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ php:
 - 7.0
 - 7.1
 - 7.2
+- 7.3
 
 before_script:
 - composer install

--- a/set-env.template.sh
+++ b/set-env.template.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=
+export AWS_SECRET_ACCESS_KEY=
+export KMS_TEST_KEY=

--- a/src/ObjectEncryptorFactory.php
+++ b/src/ObjectEncryptorFactory.php
@@ -207,13 +207,14 @@ class ObjectEncryptorFactory
     }
 
     /**
+     * @param bool $createLegacyEncryptorIfAvailable
      * @return ObjectEncryptor Object encryptor instance.
      * @throws ApplicationException
      */
-    public function getEncryptor()
+    public function getEncryptor($createLegacyEncryptorIfAvailable = false)
     {
         $this->validateState();
-        if ($this->keyVersion0 && function_exists('mcrypt_module_open')) {
+        if ($this->keyVersion0 && function_exists('mcrypt_module_open') && $createLegacyEncryptorIfAvailable) {
             $legacyEncryptor = new Encryptor($this->keyVersion0);
         } else {
             $legacyEncryptor = null;

--- a/src/ObjectEncryptorFactory.php
+++ b/src/ObjectEncryptorFactory.php
@@ -213,7 +213,7 @@ class ObjectEncryptorFactory
     public function getEncryptor()
     {
         $this->validateState();
-        if ($this->keyVersion0 && extension_loaded('mcrypt')) {
+        if ($this->keyVersion0 && function_exists('mcrypt_module_open')) {
             $legacyEncryptor = new Encryptor($this->keyVersion0);
         } else {
             $legacyEncryptor = null;

--- a/tests/EncryptorTest.php
+++ b/tests/EncryptorTest.php
@@ -9,7 +9,7 @@ class EncryptorTest extends TestCase
 {
     public function testEncryptor()
     {
-        if (!extension_loaded('mcrypt')) {
+        if (!function_exists('mcrypt_module_open')) {
             self::markTestSkipped("Mcrypt not available");
         }
         $encryptor = new Encryptor('123456789012345678901234567890ab');

--- a/tests/ObjectEncryptorTest.php
+++ b/tests/ObjectEncryptorTest.php
@@ -849,23 +849,32 @@ class ObjectEncryptorTest extends TestCase
 
     public function testEncryptorLegacyNoMCrypt()
     {
-        $encryptor = $this->factory->getEncryptor();
+        $encryptor = $this->factory->getEncryptor(true);
         $prop = new \ReflectionProperty($encryptor, 'legacyEncryptor');
         $prop->setAccessible(true);
         $legacyEncryptor = $prop->getValue($encryptor);
-        if (!extension_loaded('mcrypt')) {
+        if (!function_exists('mcrypt_module_open')) {
             self::assertNull($legacyEncryptor);
         } else {
             self::assertNotNull($legacyEncryptor);
         }
     }
 
+    public function testEncryptorLegacyNoMCryptNoRequire()
+    {
+        $encryptor = $this->factory->getEncryptor();
+        $prop = new \ReflectionProperty($encryptor, 'legacyEncryptor');
+        $prop->setAccessible(true);
+        $legacyEncryptor = $prop->getValue($encryptor);
+        self::assertNull($legacyEncryptor);
+    }
+
     public function testEncryptorLegacy()
     {
-        if (!extension_loaded('mcrypt')) {
+        if (!function_exists('mcrypt_module_open')) {
             self::markTestSkipped("Mcrypt not available");
         }
-        $encryptor = $this->factory->getEncryptor();
+        $encryptor = $this->factory->getEncryptor(true);
         $legacyEncryptor = new Encryptor($this->aesKey);
 
         $originalText = 'secret';
@@ -879,7 +888,7 @@ class ObjectEncryptorTest extends TestCase
         $encryptor = $this->factory->getEncryptor();
         $originalText = 'test';
         try {
-            $encryptor->decrypt($originalText);
+            $result = $encryptor->decrypt($originalText);
             self::fail('Invalid cipher must fail.');
         } catch (UserException $e) {
             self::assertContains('is not an encrypted value', $e->getMessage());


### PR DESCRIPTION
fix: relax mcrypt check so that phpseclib/mcrypt_compat polyfill can be also used for legacy encryption - it is already used for decryption

calls to `extension_loaded('mcrypt')` are replaced by `function_exists('mcrypt_module_open')`. But then the `testEncryptorLegacyFail` is not guaranteed to pass - https://travis-ci.org/keboola/object-encryptor/jobs/614454398. This is because of mad mcrypt behaviour, that invalid ciphers are sometimes decrypted as empty string. To maintain that behavior -- i.e. to avoid an invalid cipher to be mistakenly deciphered as empty string -- i changed it so that the legacy encryptor is added into object encryptor **only if requested** (and supported). 

i.e. here https://github.com/keboola/job-queue-internal-api-php-client/blob/617a358667e775b28b03bc166b5514e3c608ee98/src/JobFactory/Job.php#L97 the call will have to be changed to `getObjectEncryptor(true)`