### PR TITLE
chore: fix after build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+composer.lock


### PR DESCRIPTION
Je tam takovej podivnej kotrmelec s PHPstanem, kterej jede jen na php 7.1 kvuli tomu, ze to je posledni verze, kde je ten pitomej encrypt. Tady https://travis-ci.org/keboola/object-encryptor/jobs/614975154#L660 to failnulo na tom, ze si to z travis buildu natahlo composer.lock do docker buildu a timapdem se to snazi instlovat novejsi dependencies na starsi PHP - proc to neudelalo tady https://travis-ci.org/keboola/object-encryptor/jobs/614504645#L649 mi teda neni moc jasny.