### PR TITLE
Fix GCP project ID

### DIFF
--- a/provisioning/local/gcp.tf
+++ b/provisioning/local/gcp.tf
@@ -1,5 +1,5 @@
 locals {
-  gcp_project = "keboola-dev-platform-services"
+  gcp_project = "kbc-dev-platform-services"
 }
 
 provider "google" {


### PR DESCRIPTION
Je to `kbc`, ne `keboola`

![image](https://github.com/keboola/object-encryptor/assets/271753/db319688-72fd-4c4c-abf7-8d980efe3d79)
