### PR TITLE
(csas-migration) PST-2407: Add extra AKV client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "aws/aws-sdk-php": "^3.209",
         "defuse/php-encryption": "^2.3",
         "google/cloud-kms": "^1.20",
-        "keboola/azure-key-vault-client": "^3.0",
+        "keboola/azure-key-vault-client": "^4.0",
         "keboola/common-exceptions": "^1.2",
         "vkartaviy/retry": "^0.2"
     },

--- a/src/EncryptorOptions.php
+++ b/src/EncryptorOptions.php
@@ -24,6 +24,9 @@ class EncryptorOptions
     private ?string $kmsRole;
     private int $backoffMaxTries;
 
+    /** @var non-empty-string|null */
+    private ?string $encryptorId;
+
     /**
      * @param non-empty-string $stackId
      * @param non-empty-string|null $kmsKeyId
@@ -32,6 +35,7 @@ class EncryptorOptions
      * @param non-empty-string|null $akvUrl
      * @param non-empty-string|null $gkmsKeyId
      * @param int|null $backoffMaxTries
+     * @param non-empty-string|null $encryptorId
      */
     public function __construct(
         string $stackId,
@@ -41,6 +45,7 @@ class EncryptorOptions
         ?string $akvUrl = null,
         ?string $gkmsKeyId = null,
         ?int $backoffMaxTries = null,
+        ?string $encryptorId = null,
     ) {
         $this->stackId = $stackId;
         $this->kmsKeyId = $kmsKeyId;
@@ -49,6 +54,7 @@ class EncryptorOptions
         $this->akvUrl = $akvUrl;
         $this->gkmsKeyId = $gkmsKeyId;
         $this->backoffMaxTries = $backoffMaxTries ?? self::DEFAULT_BACKOFF_MAX_TRIES;
+        $this->encryptorId = $encryptorId;
         $this->validateState();
     }
 
@@ -100,6 +106,14 @@ class EncryptorOptions
     public function getBackoffMaxTries(): int
     {
         return $this->backoffMaxTries;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    public function getEncryptorId(): ?string
+    {
+        return $this->encryptorId;
     }
 
     /**

--- a/src/ObjectEncryptor.php
+++ b/src/ObjectEncryptor.php
@@ -35,6 +35,7 @@ use Keboola\ObjectEncryptor\Wrapper\ProjectKMSWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideGKMSWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideKMSWrapper;
+use Psr\Log\LoggerInterface;
 use stdClass;
 use Throwable;
 
@@ -47,7 +48,7 @@ class ObjectEncryptor
     private ?KmsClient $kmsClient = null;
     private ?KeyManagementServiceClient $gkmsClient = null;
 
-    public function __construct(EncryptorOptions $encryptorOptions)
+    public function __construct(EncryptorOptions $encryptorOptions, private readonly ?LoggerInterface $logger = null)
     {
         $this->encryptorOptions = $encryptorOptions;
     }
@@ -622,14 +623,17 @@ class ObjectEncryptor
     ): array {
         $wrappers = [];
         $wrapper = new GenericAKVWrapper($this->encryptorOptions);
+        $wrapper->logger = $this->logger;
         $wrappers[] = $wrapper;
         if ($this->encryptorOptions->getStackId()) {
             if ($projectId) {
                 $wrapper = new ProjectWideAKVWrapper($this->encryptorOptions);
+                $wrapper->logger = $this->logger;
                 $wrapper->setProjectId($projectId);
                 $wrappers[] = $wrapper;
                 if ($branchType) {
                     $wrapper = new BranchTypeProjectWideAKVWrapper($this->encryptorOptions);
+                    $wrapper->logger = $this->logger;
                     $wrapper->setProjectId($projectId);
                     $wrapper->setBranchType($branchType);
                     $wrappers[] = $wrapper;
@@ -637,21 +641,25 @@ class ObjectEncryptor
             }
             if ($componentId) {
                 $wrapper = new ComponentAKVWrapper($this->encryptorOptions);
+                $wrapper->logger = $this->logger;
                 $wrapper->setComponentId($componentId);
                 $wrappers[] = $wrapper;
                 if ($projectId) {
                     $wrapper = new ProjectAKVWrapper($this->encryptorOptions);
+                    $wrapper->logger = $this->logger;
                     $wrapper->setComponentId($componentId);
                     $wrapper->setProjectId($projectId);
                     $wrappers[] = $wrapper;
                     if ($configurationId) {
                         $wrapper = new ConfigurationAKVWrapper($this->encryptorOptions);
+                        $wrapper->logger = $this->logger;
                         $wrapper->setComponentId($componentId);
                         $wrapper->setProjectId($projectId);
                         $wrapper->setConfigurationId($configurationId);
                         $wrappers[] = $wrapper;
                         if ($branchType) {
                             $wrapper = new BranchTypeConfigurationAKVWrapper($this->encryptorOptions);
+                            $wrapper->logger = $this->logger;
                             $wrapper->setComponentId($componentId);
                             $wrapper->setProjectId($projectId);
                             $wrapper->setConfigurationId($configurationId);
@@ -661,6 +669,7 @@ class ObjectEncryptor
                     }
                     if ($branchType) {
                         $wrapper = new BranchTypeProjectAKVWrapper($this->encryptorOptions);
+                        $wrapper->logger = $this->logger;
                         $wrapper->setComponentId($componentId);
                         $wrapper->setProjectId($projectId);
                         $wrapper->setBranchType($branchType);

--- a/src/ObjectEncryptorFactory.php
+++ b/src/ObjectEncryptorFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\ObjectEncryptor;
 
+use Psr\Log\LoggerInterface;
+
 class ObjectEncryptorFactory
 {
     /**
@@ -28,10 +30,13 @@ class ObjectEncryptorFactory
      * @param non-empty-string $keyVaultUrl
      * @return ObjectEncryptor
      */
-    public static function getAzureEncryptor(string $stackId, string $keyVaultUrl): ObjectEncryptor
-    {
+    public static function getAzureEncryptor(
+        string $stackId,
+        string $keyVaultUrl,
+        ?LoggerInterface $logger = null,
+    ): ObjectEncryptor {
         $encryptOptions = new EncryptorOptions($stackId, null, null, null, $keyVaultUrl);
-        return self::getEncryptor($encryptOptions);
+        return self::getEncryptor($encryptOptions, $logger);
     }
 
     /**
@@ -45,8 +50,10 @@ class ObjectEncryptorFactory
         return self::getEncryptor($encryptOptions);
     }
 
-    public static function getEncryptor(EncryptorOptions $encryptorOptions): ObjectEncryptor
-    {
-        return new ObjectEncryptor($encryptorOptions);
+    public static function getEncryptor(
+        EncryptorOptions $encryptorOptions,
+        ?LoggerInterface $logger = null,
+    ): ObjectEncryptor {
+        return new ObjectEncryptor($encryptorOptions, $logger);
     }
 }

--- a/src/Temporary/CallbackRetryPolicy.php
+++ b/src/Temporary/CallbackRetryPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Temporary;
+
+use Closure;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryContextInterface;
+
+class CallbackRetryPolicy extends SimpleRetryPolicy
+{
+    private Closure $shouldRetryCallback;
+
+    public function __construct(
+        callable $shouldRetryCallback,
+        int $maxAttempts = 3,
+    ) {
+        parent::__construct($maxAttempts);
+        $this->shouldRetryCallback = $shouldRetryCallback(...);
+    }
+
+    public function canRetry(RetryContextInterface $context): bool
+    {
+        $e = $context->getLastException();
+
+        if (($this->shouldRetryCallback)($e, $context) !== true) {
+            return false;
+        }
+
+        return parent::canRetry($context);
+    }
+}

--- a/src/Temporary/TransAuthenticatorFactory.php
+++ b/src/Temporary/TransAuthenticatorFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Temporary;
+
+use Keboola\AzureKeyVaultClient\Authentication\AuthenticatorFactory;
+use Keboola\AzureKeyVaultClient\Authentication\AuthenticatorInterface;
+use Keboola\AzureKeyVaultClient\Exception\ClientException;
+use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
+
+class TransAuthenticatorFactory extends AuthenticatorFactory
+{
+    public function getAuthenticator(GuzzleClientFactory $clientFactory, string $resource): AuthenticatorInterface
+    {
+        $authenticator = new TransClientCredentialsEnvironmentAuthenticator($clientFactory, $resource);
+        try {
+            $authenticator->checkUsability();
+            return $authenticator;
+        } catch (ClientException) {
+            throw new TransClientNotAvailableException;
+        }
+    }
+}

--- a/src/Temporary/TransClient.php
+++ b/src/Temporary/TransClient.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Temporary;
+
+use Keboola\AzureKeyVaultClient\Client;
+use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
+
+class TransClient extends Client
+{
+    public function __construct(GuzzleClientFactory $clientFactory, ?string $encryptorId)
+    {
+        $vaultBaseUrl = (string) getenv(self::determinateVaultUrlEnvName($encryptorId));
+
+        if ($vaultBaseUrl === '') {
+            throw new TransClientNotAvailableException;
+        }
+
+        parent::__construct(
+            $clientFactory,
+            new TransAuthenticatorFactory(),
+            $vaultBaseUrl,
+        );
+    }
+
+    public static function determinateVaultUrlEnvName(?string $encryptorId): string
+    {
+        $transEnvName = 'TRANS_AZURE_KEY_VAULT_URL';
+
+        if (!empty($encryptorId)) { // not null or empty string
+            $suffix = (string) preg_replace('/[\s\-_]+/', '_', $encryptorId);
+            $suffix = trim($suffix, '_');
+            $transEnvName .= sprintf('_%s', strtoupper($suffix));
+        }
+
+        return $transEnvName;
+    }
+}

--- a/src/Temporary/TransClientCredentialsEnvironmentAuthenticator.php
+++ b/src/Temporary/TransClientCredentialsEnvironmentAuthenticator.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Temporary;
+
+use Keboola\AzureKeyVaultClient\Authentication\ClientCredentialsEnvironmentAuthenticator;
+
+class TransClientCredentialsEnvironmentAuthenticator extends ClientCredentialsEnvironmentAuthenticator
+{
+    protected const ENV_AZURE_TENANT_ID = 'TRANS_AZURE_TENANT_ID';
+    protected const ENV_AZURE_CLIENT_ID = 'TRANS_AZURE_CLIENT_ID';
+    protected const ENV_AZURE_CLIENT_SECRET = 'TRANS_AZURE_CLIENT_SECRET';
+}

--- a/src/Temporary/TransClientNotAvailableException.php
+++ b/src/Temporary/TransClientNotAvailableException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Temporary;
+
+use Exception;
+
+class TransClientNotAvailableException extends Exception
+{
+}

--- a/src/Wrapper/GenericAKVWrapper.php
+++ b/src/Wrapper/GenericAKVWrapper.php
@@ -235,7 +235,7 @@ class GenericAKVWrapper implements CryptoWrapperInterface
             $doBackfill = false;
             throw new ApplicationException('Deciphering failed.', $e->getCode(), $e);
         } finally {
-            if (!self::getTransStackId()) {
+            if ($doBackfill && !self::getTransStackId()) {
                 $doBackfill = false;
                 $this->logger?->error(sprintf('Env %s not set.', self::TRANS_STACK_ID_ENV));
             }

--- a/tests/EncryptorOptionsTest.php
+++ b/tests/EncryptorOptionsTest.php
@@ -20,6 +20,7 @@ class EncryptorOptionsTest extends TestCase
             akvUrl: 'akv-url',
             gkmsKeyId: 'gkms-key-id',
             backoffMaxTries: 1,
+            encryptorId: 'internal',
         );
         self::assertSame('my-stack', $options->getStackId());
         self::assertSame('my-kms-id', $options->getKmsKeyId());
@@ -28,6 +29,7 @@ class EncryptorOptionsTest extends TestCase
         self::assertSame('akv-url', $options->getAkvUrl());
         self::assertSame('gkms-key-id', $options->getGkmsKeyId());
         self::assertSame(1, $options->getBackoffMaxTries());
+        self::assertSame('internal', $options->getEncryptorId());
     }
 
     public function testConstructEmptyConfig(): void

--- a/tests/Temporary/AKVWrappersWithTransClientTest.php
+++ b/tests/Temporary/AKVWrappersWithTransClientTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Keboola\ObjectEncryptor\Tests\Temporary;
 
+use Defuse\Crypto\Crypto;
+use Defuse\Crypto\Key;
+use Keboola\AzureKeyVaultClient\Client;
+use Keboola\AzureKeyVaultClient\Exception\ClientException;
+use Keboola\AzureKeyVaultClient\Requests\SetSecretRequest;
+use Keboola\AzureKeyVaultClient\Responses\SecretBundle;
 use Keboola\ObjectEncryptor\EncryptorOptions;
 use Keboola\ObjectEncryptor\Temporary\TransClient;
 use Keboola\ObjectEncryptor\Wrapper\BranchTypeConfigurationAKVWrapper;
@@ -14,6 +20,7 @@ use Keboola\ObjectEncryptor\Wrapper\ConfigurationAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\GenericAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideAKVWrapper;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AKVWrappersWithTransClientTest extends TestCase
@@ -25,26 +32,80 @@ class AKVWrappersWithTransClientTest extends TestCase
         putenv('TRANS_AZURE_TENANT_ID=');
         putenv('TRANS_AZURE_CLIENT_ID=');
         putenv('TRANS_AZURE_CLIENT_SECRET=');
+        putenv('TRANS_ENCRYPTOR_STACK_ID=');
     }
 
     public static function provideAKVWrappers(): iterable
     {
-        $classes = [
-            GenericAKVWrapper::class,
-            ComponentAKVWrapper::class,
-            ProjectAKVWrapper::class,
-            ConfigurationAKVWrapper::class,
-            ProjectWideAKVWrapper::class,
-            BranchTypeProjectAKVWrapper::class,
-            BranchTypeProjectWideAKVWrapper::class,
-            BranchTypeConfigurationAKVWrapper::class,
+        yield GenericAKVWrapper::class => [
+            'wrapperClass' => GenericAKVWrapper::class,
+            'metadata' => [],
         ];
 
-        foreach ($classes as $className) {
-            yield $className => [
-                'wrapperClass' => $className,
-            ];
-        }
+        yield ComponentAKVWrapper::class => [
+            'wrapperClass' => ComponentAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+            ],
+        ];
+
+        yield ProjectAKVWrapper::class => [
+            'wrapperClass' => ProjectAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+            ],
+        ];
+
+        yield ConfigurationAKVWrapper::class => [
+            'wrapperClass' => ConfigurationAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+                'configurationId' => 'config-id',
+            ],
+        ];
+
+        yield ProjectWideAKVWrapper::class => [
+            'wrapperClass' => ProjectWideAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'projectId' => 'project-id',
+            ],
+        ];
+
+        yield BranchTypeProjectAKVWrapper::class => [
+            'wrapperClass' => BranchTypeProjectAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+                'branchType' => 'branch-type',
+            ],
+        ];
+
+        yield BranchTypeConfigurationAKVWrapper::class => [
+            'wrapperClass' => BranchTypeConfigurationAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+                'configurationId' => 'config-id',
+                'branchType' => 'branch-type',
+            ],
+        ];
+
+        yield BranchTypeProjectWideAKVWrapper::class => [
+            'wrapperClass' => BranchTypeProjectWideAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'projectId' => 'project-id',
+                'branchType' => 'branch-type',
+            ],
+        ];
     }
 
     /**
@@ -146,5 +207,196 @@ class AKVWrappersWithTransClientTest extends TestCase
             encryptorId: 'extra-sausage',
         ));
         self::assertNull($wrapper->getTransClient());
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testDecryptWithBackfillWhenSecretNotFoundInTransVault(
+        string $wrapperClass,
+        array $metadata,
+    ): void {
+        putenv('TRANS_ENCRYPTOR_STACK_ID=trans-stack');
+
+        $key = Key::createNewRandomKey();
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => $metadata,
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willThrowException(new ClientException('not found', 404));
+        $mockTransClient->expects(self::once())
+            ->method('setSecret')
+            ->with(
+                self::callback(function ($arg) use ($key, $metadata) {
+                    self::assertInstanceOf(SetSecretRequest::class, $arg);
+
+                    if (array_key_exists('stackId', $metadata)) {
+                        $metadata['stackId'] = 'trans-stack';
+                    }
+                    $encodedKey = self::encode([
+                        0 => $metadata,
+                        1 => $key->saveToAsciiSafeString(),
+                    ]);
+
+                    self::assertSame($encodedKey, $arg->getArray()['value']);
+                    return true;
+                }),
+                'secret-name',
+            );
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder($wrapperClass)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        foreach ($metadata as $metaKey => $metaValue) {
+            $mockWrapper->setMetadataValue($metaKey, $metaValue);
+        }
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::atLeast(3))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testDecryptOmitsPrimaryVaultWhenSecretFoundInTransVault(
+        string $wrapperClass,
+        array $metadata,
+    ): void {
+        $key = Key::createNewRandomKey();
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => $metadata,
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+        $mockTransClient->expects(self::never())->method('setSecret');
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder($wrapperClass)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        foreach ($metadata as $metaKey => $metaValue) {
+            $mockWrapper->setMetadataValue($metaKey, $metaValue);
+        }
+        $mockWrapper->expects(self::never())->method('getClient');
+        $mockWrapper->expects(self::exactly(2))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+    }
+
+    public function testRetrieveFromPrimaryVaultWhenTransVaultRetrievalFails(): void
+    {
+        $key = Key::createNewRandomKey();
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => [],
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::exactly(3))
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willThrowException(new ClientException('something failed', 500));
+        $mockTransClient->expects(self::never())->method('setSecret');
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder(GenericAKVWrapper::class)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::exactly(4))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+    }
+
+    private static function encode(mixed $data): string
+    {
+        return base64_encode((string) gzcompress(serialize($data)));
     }
 }

--- a/tests/Temporary/AKVWrappersWithTransClientTest.php
+++ b/tests/Temporary/AKVWrappersWithTransClientTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Tests\Temporary;
+
+use Keboola\ObjectEncryptor\EncryptorOptions;
+use Keboola\ObjectEncryptor\Temporary\TransClient;
+use Keboola\ObjectEncryptor\Wrapper\BranchTypeConfigurationAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\BranchTypeProjectAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\BranchTypeProjectWideAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\ComponentAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\ConfigurationAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\GenericAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\ProjectAKVWrapper;
+use Keboola\ObjectEncryptor\Wrapper\ProjectWideAKVWrapper;
+use PHPUnit\Framework\TestCase;
+
+class AKVWrappersWithTransClientTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('TRANS_AZURE_TENANT_ID=');
+        putenv('TRANS_AZURE_CLIENT_ID=');
+        putenv('TRANS_AZURE_CLIENT_SECRET=');
+    }
+
+    public static function provideAKVWrappers(): iterable
+    {
+        $classes = [
+            GenericAKVWrapper::class,
+            ComponentAKVWrapper::class,
+            ProjectAKVWrapper::class,
+            ConfigurationAKVWrapper::class,
+            ProjectWideAKVWrapper::class,
+            BranchTypeProjectAKVWrapper::class,
+            BranchTypeProjectWideAKVWrapper::class,
+            BranchTypeConfigurationAKVWrapper::class,
+        ];
+
+        foreach ($classes as $className) {
+            yield $className => [
+                'wrapperClass' => $className,
+            ];
+        }
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testWrappersDoNotHaveTransClientInitializedWhenTransEnvsMissing(
+        string $wrapperClass,
+    ): void {
+        $encryptorOptions = new EncryptorOptions(
+            stackId: 'some-stack',
+            akvUrl: 'some-url',
+        );
+
+        $wrapper = new $wrapperClass($encryptorOptions);
+
+        self::assertNull($wrapper->getTransClient());
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testWrappersHaveTransClientInitialized(
+        string $wrapperClass,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        putenv('TRANS_AZURE_KEY_VAULT_URL=https://vault-url');
+
+        $encryptorOptions = new EncryptorOptions(
+            stackId: 'some-stack',
+            akvUrl: 'some-url',
+        );
+
+        $wrapper = new $wrapperClass($encryptorOptions);
+
+        $transClient = $wrapper->getTransClient();
+        self::assertInstanceOf(TransClient::class, $transClient);
+
+        // ensure getter returns a single instance of the TransClient
+        self::assertSame($transClient, $wrapper->getTransClient());
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testWrappersHaveTransClientWhenEncryptorIdMatches(
+        string $wrapperClass,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        putenv('TRANS_AZURE_KEY_VAULT_URL=');
+        putenv('TRANS_AZURE_KEY_VAULT_URL_EXTRA_BRATWURST=https://german-vault-url');
+
+        $encryptorOptions = new EncryptorOptions(
+            stackId: 'some-stack',
+            akvUrl: 'some-url',
+            encryptorId: 'extra-bratwurst',
+        );
+
+        $wrapper = new $wrapperClass($encryptorOptions);
+
+        $transClient = $wrapper->getTransClient();
+        self::assertInstanceOf(TransClient::class, $transClient);
+
+        // ensure getter returns a single instance of the TransClient
+        self::assertSame($transClient, $wrapper->getTransClient());
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testWrappersDoNotHaveTransClientWhenEncryptorIdMismatches(
+        string $wrapperClass,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        putenv('TRANS_AZURE_KEY_VAULT_URL=');
+        putenv('TRANS_AZURE_KEY_VAULT_URL_EXTRA_BRATWURST=https://german-vault-url');
+
+        // null encryptorId
+        $wrapper = new $wrapperClass(new EncryptorOptions(
+            stackId: 'some-stack',
+            akvUrl: 'some-url',
+            encryptorId: null,
+        ));
+        self::assertNull($wrapper->getTransClient());
+
+        // encryptorId does not match env suffix ('extra-sausage' vs. _EXTRA_BRATWURST)
+        $wrapper = new $wrapperClass(new EncryptorOptions(
+            stackId: 'some-stack',
+            akvUrl: 'some-url',
+            encryptorId: 'extra-sausage',
+        ));
+        self::assertNull($wrapper->getTransClient());
+    }
+}

--- a/tests/Temporary/AKVWrappersWithTransClientTest.php
+++ b/tests/Temporary/AKVWrappersWithTransClientTest.php
@@ -466,6 +466,64 @@ class AKVWrappersWithTransClientTest extends TestCase
         ]));
     }
 
+    public function testSkipBackfillWhenTransStackIdEnvNotSet(): void
+    {
+        putenv('TRANS_ENCRYPTOR_STACK_ID=');
+
+        $key = Key::createNewRandomKey();
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => [],
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willThrowException(new ClientException('not found', 404));
+        $mockTransClient->expects(self::never())->method('setSecret');
+
+        $logger = new TestLogger();
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder(GenericAKVWrapper::class)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        $mockWrapper->logger = $logger;
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::exactly(2))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+        self::assertTrue($logger->hasError('Env TRANS_ENCRYPTOR_STACK_ID not set.'));
+    }
+
     public function testObjectEncryptorFactoryInjectsLoggerInAKVWrappers(): void
     {
         $logger = new TestLogger();

--- a/tests/Temporary/TransAuthenticatorFactoryTest.php
+++ b/tests/Temporary/TransAuthenticatorFactoryTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Tests\Temporary;
+
+use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
+use Keboola\ObjectEncryptor\Temporary\TransAuthenticatorFactory;
+use Keboola\ObjectEncryptor\Temporary\TransClientNotAvailableException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class TransAuthenticatorFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        putenv('TRANS_AZURE_TENANT_ID=');
+        putenv('TRANS_AZURE_CLIENT_ID=');
+        putenv('TRANS_AZURE_CLIENT_SECRET=');
+    }
+
+    public function testTransAuthenticatorIsAvailable(): void
+    {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+
+        $transAuthFactory = new TransAuthenticatorFactory();
+
+        try {
+            $transAuthFactory->getAuthenticator(
+                new GuzzleClientFactory(new NullLogger()),
+                'https://vault.azure.net',
+            );
+            self::assertTrue(true);
+        } catch (TransClientNotAvailableException) {
+            self::fail('Test should not have thrown an exception');
+        }
+    }
+
+    public static function provideInvalidTransEnvs(): iterable
+    {
+        yield 'missing all' => [
+            [],
+        ];
+
+        yield 'missing TRANS_AZURE_TENANT_ID' => [
+            [
+                'TRANS_AZURE_TENANT_ID' => '',
+                'TRANS_AZURE_CLIENT_ID' => 'client-id',
+                'TRANS_AZURE_CLIENT_SECRET' => 'client-secret',
+            ],
+        ];
+
+        yield 'missing TRANS_AZURE_CLIENT_ID' => [
+            [
+                'TRANS_AZURE_TENANT_ID' => 'tenant-id',
+                'TRANS_AZURE_CLIENT_ID' => '',
+                'TRANS_AZURE_CLIENT_SECRET' => 'client-secret',
+            ],
+        ];
+
+        yield 'missing TRANS_AZURE_CLIENT_SECRET' => [
+            [
+                'TRANS_AZURE_TENANT_ID' => 'tenant-id',
+                'TRANS_AZURE_CLIENT_ID' => 'client-id',
+                'TRANS_AZURE_CLIENT_SECRET' => '',
+            ],
+        ];
+    }
+
+    /** @dataProvider provideInvalidTransEnvs */
+    public function testTransAuthenticatorIsUnavailable(array $invalidEnvs): void
+    {
+        foreach ($invalidEnvs as $name => $value) {
+            putenv(sprintf('%s=%s', $name, $value));
+        }
+
+        $transAuthFactory = new TransAuthenticatorFactory();
+
+        $this->expectException(TransClientNotAvailableException::class);
+
+        $transAuthFactory->getAuthenticator(
+            new GuzzleClientFactory(new NullLogger()),
+            'https://vault.azure.net',
+        );
+    }
+}

--- a/tests/Temporary/TransClientTest.php
+++ b/tests/Temporary/TransClientTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Tests\Temporary;
+
+use Keboola\AzureKeyVaultClient\GuzzleClientFactory;
+use Keboola\ObjectEncryptor\Temporary\TransClient;
+use Keboola\ObjectEncryptor\Temporary\TransClientNotAvailableException;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+class TransClientTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        putenv('TRANS_AZURE_TENANT_ID=');
+        putenv('TRANS_AZURE_CLIENT_ID=');
+        putenv('TRANS_AZURE_CLIENT_SECRET=');
+
+        $definedEnvsInProviders = array_column([
+            ...self::provideTransClientUrlTestData(),
+            ...self::provideTransClientMismatchEnvsTestData(),
+            ], 'envs');
+        foreach (array_keys(array_merge(...$definedEnvsInProviders)) as $envName) {
+            putenv(sprintf('%s=', $envName));
+        }
+    }
+
+    public static function provideDeterminateVaultUrlEnvNameTestData(): iterable
+    {
+        yield 'encryptorId is null' => [
+            'encryptorId' => null,
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL',
+        ];
+        yield 'encryptorId is empty' => [
+            'encryptorId' => '',
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL',
+        ];
+        yield 'encryptorId = "internal"' => [
+            'encryptorId' => 'internal',
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL_INTERNAL',
+        ];
+        yield 'encryptorId = "job_queue"' => [
+            'encryptorId' => 'job_queue',
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL_JOB_QUEUE',
+        ];
+        yield 'encryptorId = "job__queue_"' => [
+            'encryptorId' => 'job__queue_',
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL_JOB_QUEUE',
+        ];
+        yield 'encryptorId = "job-queue"' => [
+            'encryptorId' => 'job-queue',
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL_JOB_QUEUE',
+        ];
+        yield 'encryptorId = "job queue"' => [
+            'encryptorId' => 'job queue',
+            'expectedEnvName' => 'TRANS_AZURE_KEY_VAULT_URL_JOB_QUEUE',
+        ];
+    }
+
+    /** @dataProvider provideDeterminateVaultUrlEnvNameTestData */
+    public function testDeterminateVaultUrlEnvName(
+        ?string $encryptorId,
+        string $expectedEnvName,
+    ): void {
+        self::assertSame(
+            $expectedEnvName,
+            TransClient::determinateVaultUrlEnvName($encryptorId),
+        );
+    }
+
+    public static function provideTransClientUrlTestData(): iterable
+    {
+        yield 'encryptorId is null' => [
+            'encryptorId' => null,
+            'envs' => [
+                'TRANS_AZURE_KEY_VAULT_URL' => 'https://vault-url',
+            ],
+            'expectedClientUrl' => 'https://vault-url',
+        ];
+
+        yield 'encryptorId = "internal"' => [
+            'encryptorId' => 'internal',
+            'envs' => [
+                'TRANS_AZURE_KEY_VAULT_URL_INTERNAL' => 'https://internal-vault-url',
+            ],
+            'expectedClientUrl' => 'https://internal-vault-url',
+        ];
+    }
+
+    /** @dataProvider provideTransClientUrlTestData */
+    public function testTransClientUrl(
+        ?string $encryptorId,
+        array $envs,
+        string $expectedVaultUrl,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        foreach ($envs as $envName => $envValue) {
+            putenv(sprintf('%s=%s', $envName, $envValue));
+        }
+
+        $guzzleClientFactoryCounter = self::exactly(2);
+        $guzzleClientFactoryMock = $this->createMock(GuzzleClientFactory::class);
+        $guzzleClientFactoryMock->expects($guzzleClientFactoryCounter)
+            ->method('getClient')
+            ->with(
+                self::callback(fn($url) => match ($guzzleClientFactoryCounter->getInvocationCount()) {
+                    1 => $url === $expectedVaultUrl,
+                    2 => $url === 'https://management.azure.com/metadata/endpoints?api-version=2020-01-01',
+                    default => self::fail('Unexpected url: ' . $url),
+                }),
+                self::isType('array'),
+            );
+
+        try {
+            new TransClient(
+                $guzzleClientFactoryMock,
+                $encryptorId,
+            );
+        } catch (TransClientNotAvailableException) {
+            self::fail('Test should not have thrown an exception');
+        }
+    }
+
+    public static function provideTransClientMismatchEnvsTestData(): iterable
+    {
+        yield 'encryptorId is null, env has suffix' => [
+            'encryptorId' => null,
+            'envs' => [
+                'TRANS_AZURE_KEY_VAULT_URL_SOMETHING' => 'https://vault-url',
+            ],
+        ];
+
+        yield 'encryptorId = "internal", env suffix is missing' => [
+            'encryptorId' => 'internal',
+            'envs' => [
+                'TRANS_AZURE_KEY_VAULT_URL' => 'https://vault-url',
+            ],
+        ];
+    }
+
+    /** @dataProvider provideTransClientMismatchEnvsTestData */
+    public function testTransClientMismatchEnvs(
+        ?string $encryptorId,
+        array $envs,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        foreach ($envs as $envName => $envValue) {
+            putenv(sprintf('%s=%s', $envName, $envValue));
+        }
+
+        $this->expectException(TransClientNotAvailableException::class);
+
+        new TransClient(
+            new GuzzleClientFactory(new NullLogger()),
+            $encryptorId,
+        );
+    }
+}


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2407

Add `TransClient` as an extra AKV client initialized with `TRANS_` envs. If all required `TRANS_` envs are present, `GenericAKVWrapper::getTransClient()` returns an instance of `TransClient`; otherwise, it returns null.

> [!NOTE]
>  Merged followup: https://github.com/keboola/object-encryptor/pull/52 