### PR TITLE
(csas-migration) PST-2410: Backfill into new AKV during decrypt()

### DIFF
--- a/src/ObjectEncryptor.php
+++ b/src/ObjectEncryptor.php
@@ -35,6 +35,7 @@ use Keboola\ObjectEncryptor\Wrapper\ProjectKMSWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideGKMSWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideKMSWrapper;
+use Psr\Log\LoggerInterface;
 use stdClass;
 use Throwable;
 
@@ -47,7 +48,7 @@ class ObjectEncryptor
     private ?KmsClient $kmsClient = null;
     private ?KeyManagementServiceClient $gkmsClient = null;
 
-    public function __construct(EncryptorOptions $encryptorOptions)
+    public function __construct(EncryptorOptions $encryptorOptions, private readonly ?LoggerInterface $logger = null)
     {
         $this->encryptorOptions = $encryptorOptions;
     }
@@ -622,14 +623,17 @@ class ObjectEncryptor
     ): array {
         $wrappers = [];
         $wrapper = new GenericAKVWrapper($this->encryptorOptions);
+        $wrapper->logger = $this->logger;
         $wrappers[] = $wrapper;
         if ($this->encryptorOptions->getStackId()) {
             if ($projectId) {
                 $wrapper = new ProjectWideAKVWrapper($this->encryptorOptions);
+                $wrapper->logger = $this->logger;
                 $wrapper->setProjectId($projectId);
                 $wrappers[] = $wrapper;
                 if ($branchType) {
                     $wrapper = new BranchTypeProjectWideAKVWrapper($this->encryptorOptions);
+                    $wrapper->logger = $this->logger;
                     $wrapper->setProjectId($projectId);
                     $wrapper->setBranchType($branchType);
                     $wrappers[] = $wrapper;
@@ -637,21 +641,25 @@ class ObjectEncryptor
             }
             if ($componentId) {
                 $wrapper = new ComponentAKVWrapper($this->encryptorOptions);
+                $wrapper->logger = $this->logger;
                 $wrapper->setComponentId($componentId);
                 $wrappers[] = $wrapper;
                 if ($projectId) {
                     $wrapper = new ProjectAKVWrapper($this->encryptorOptions);
+                    $wrapper->logger = $this->logger;
                     $wrapper->setComponentId($componentId);
                     $wrapper->setProjectId($projectId);
                     $wrappers[] = $wrapper;
                     if ($configurationId) {
                         $wrapper = new ConfigurationAKVWrapper($this->encryptorOptions);
+                        $wrapper->logger = $this->logger;
                         $wrapper->setComponentId($componentId);
                         $wrapper->setProjectId($projectId);
                         $wrapper->setConfigurationId($configurationId);
                         $wrappers[] = $wrapper;
                         if ($branchType) {
                             $wrapper = new BranchTypeConfigurationAKVWrapper($this->encryptorOptions);
+                            $wrapper->logger = $this->logger;
                             $wrapper->setComponentId($componentId);
                             $wrapper->setProjectId($projectId);
                             $wrapper->setConfigurationId($configurationId);
@@ -661,6 +669,7 @@ class ObjectEncryptor
                     }
                     if ($branchType) {
                         $wrapper = new BranchTypeProjectAKVWrapper($this->encryptorOptions);
+                        $wrapper->logger = $this->logger;
                         $wrapper->setComponentId($componentId);
                         $wrapper->setProjectId($projectId);
                         $wrapper->setBranchType($branchType);

--- a/src/ObjectEncryptorFactory.php
+++ b/src/ObjectEncryptorFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Keboola\ObjectEncryptor;
 
+use Psr\Log\LoggerInterface;
+
 class ObjectEncryptorFactory
 {
     /**
@@ -28,10 +30,13 @@ class ObjectEncryptorFactory
      * @param non-empty-string $keyVaultUrl
      * @return ObjectEncryptor
      */
-    public static function getAzureEncryptor(string $stackId, string $keyVaultUrl): ObjectEncryptor
-    {
+    public static function getAzureEncryptor(
+        string $stackId,
+        string $keyVaultUrl,
+        ?LoggerInterface $logger = null,
+    ): ObjectEncryptor {
         $encryptOptions = new EncryptorOptions($stackId, null, null, null, $keyVaultUrl);
-        return self::getEncryptor($encryptOptions);
+        return self::getEncryptor($encryptOptions, $logger);
     }
 
     /**
@@ -45,8 +50,10 @@ class ObjectEncryptorFactory
         return self::getEncryptor($encryptOptions);
     }
 
-    public static function getEncryptor(EncryptorOptions $encryptorOptions): ObjectEncryptor
-    {
-        return new ObjectEncryptor($encryptorOptions);
+    public static function getEncryptor(
+        EncryptorOptions $encryptorOptions,
+        ?LoggerInterface $logger = null,
+    ): ObjectEncryptor {
+        return new ObjectEncryptor($encryptorOptions, $logger);
     }
 }

--- a/src/Temporary/CallbackRetryPolicy.php
+++ b/src/Temporary/CallbackRetryPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Keboola\ObjectEncryptor\Temporary;
+
+use Closure;
+use Retry\Policy\SimpleRetryPolicy;
+use Retry\RetryContextInterface;
+
+class CallbackRetryPolicy extends SimpleRetryPolicy
+{
+    private Closure $shouldRetryCallback;
+
+    public function __construct(
+        callable $shouldRetryCallback,
+        int $maxAttempts = 3,
+    ) {
+        parent::__construct($maxAttempts);
+        $this->shouldRetryCallback = $shouldRetryCallback(...);
+    }
+
+    public function canRetry(RetryContextInterface $context): bool
+    {
+        $e = $context->getLastException();
+
+        if (($this->shouldRetryCallback)($e, $context) !== true) {
+            return false;
+        }
+
+        return parent::canRetry($context);
+    }
+}

--- a/tests/Temporary/AKVWrappersWithTransClientTest.php
+++ b/tests/Temporary/AKVWrappersWithTransClientTest.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace Keboola\ObjectEncryptor\Tests\Temporary;
 
+use Defuse\Crypto\Crypto;
+use Defuse\Crypto\Key;
+use Keboola\AzureKeyVaultClient\Client;
+use Keboola\AzureKeyVaultClient\Exception\ClientException;
+use Keboola\AzureKeyVaultClient\Requests\SetSecretRequest;
+use Keboola\AzureKeyVaultClient\Responses\SecretBundle;
 use Keboola\ObjectEncryptor\EncryptorOptions;
 use Keboola\ObjectEncryptor\Temporary\TransClient;
 use Keboola\ObjectEncryptor\Wrapper\BranchTypeConfigurationAKVWrapper;
@@ -14,6 +20,7 @@ use Keboola\ObjectEncryptor\Wrapper\ConfigurationAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\GenericAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectAKVWrapper;
 use Keboola\ObjectEncryptor\Wrapper\ProjectWideAKVWrapper;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class AKVWrappersWithTransClientTest extends TestCase
@@ -25,26 +32,80 @@ class AKVWrappersWithTransClientTest extends TestCase
         putenv('TRANS_AZURE_TENANT_ID=');
         putenv('TRANS_AZURE_CLIENT_ID=');
         putenv('TRANS_AZURE_CLIENT_SECRET=');
+        putenv('TRANS_ENCRYPTOR_STACK_ID=');
     }
 
     public static function provideAKVWrappers(): iterable
     {
-        $classes = [
-            GenericAKVWrapper::class,
-            ComponentAKVWrapper::class,
-            ProjectAKVWrapper::class,
-            ConfigurationAKVWrapper::class,
-            ProjectWideAKVWrapper::class,
-            BranchTypeProjectAKVWrapper::class,
-            BranchTypeProjectWideAKVWrapper::class,
-            BranchTypeConfigurationAKVWrapper::class,
+        yield GenericAKVWrapper::class => [
+            'wrapperClass' => GenericAKVWrapper::class,
+            'metadata' => [],
         ];
 
-        foreach ($classes as $className) {
-            yield $className => [
-                'wrapperClass' => $className,
-            ];
-        }
+        yield ComponentAKVWrapper::class => [
+            'wrapperClass' => ComponentAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+            ],
+        ];
+
+        yield ProjectAKVWrapper::class => [
+            'wrapperClass' => ProjectAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+            ],
+        ];
+
+        yield ConfigurationAKVWrapper::class => [
+            'wrapperClass' => ConfigurationAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+                'configurationId' => 'config-id',
+            ],
+        ];
+
+        yield ProjectWideAKVWrapper::class => [
+            'wrapperClass' => ProjectWideAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'projectId' => 'project-id',
+            ],
+        ];
+
+        yield BranchTypeProjectAKVWrapper::class => [
+            'wrapperClass' => BranchTypeProjectAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+                'branchType' => 'branch-type',
+            ],
+        ];
+
+        yield BranchTypeConfigurationAKVWrapper::class => [
+            'wrapperClass' => BranchTypeConfigurationAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'componentId' => 'component-id',
+                'projectId' => 'project-id',
+                'configurationId' => 'config-id',
+                'branchType' => 'branch-type',
+            ],
+        ];
+
+        yield BranchTypeProjectWideAKVWrapper::class => [
+            'wrapperClass' => BranchTypeProjectWideAKVWrapper::class,
+            'metadata' => [
+                'stackId' => 'some-stack',
+                'projectId' => 'project-id',
+                'branchType' => 'branch-type',
+            ],
+        ];
     }
 
     /**
@@ -146,5 +207,196 @@ class AKVWrappersWithTransClientTest extends TestCase
             encryptorId: 'extra-sausage',
         ));
         self::assertNull($wrapper->getTransClient());
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testDecryptWithBackfillWhenSecretNotFoundInTransVault(
+        string $wrapperClass,
+        array $metadata,
+    ): void {
+        putenv('TRANS_ENCRYPTOR_STACK_ID=trans-stack');
+
+        $key = Key::createNewRandomKey();
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => $metadata,
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willThrowException(new ClientException('not found', 404));
+        $mockTransClient->expects(self::once())
+            ->method('setSecret')
+            ->with(
+                self::callback(function ($arg) use ($key, $metadata) {
+                    self::assertInstanceOf(SetSecretRequest::class, $arg);
+
+                    if (array_key_exists('stackId', $metadata)) {
+                        $metadata['stackId'] = 'trans-stack';
+                    }
+                    $encodedKey = self::encode([
+                        0 => $metadata,
+                        1 => $key->saveToAsciiSafeString(),
+                    ]);
+
+                    self::assertSame($encodedKey, $arg->getArray()['value']);
+                    return true;
+                }),
+                'secret-name',
+            );
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder($wrapperClass)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        foreach ($metadata as $metaKey => $metaValue) {
+            $mockWrapper->setMetadataValue($metaKey, $metaValue);
+        }
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::atLeast(3))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testDecryptOmitsPrimaryVaultWhenSecretFoundInTransVault(
+        string $wrapperClass,
+        array $metadata,
+    ): void {
+        $key = Key::createNewRandomKey();
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => $metadata,
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+        $mockTransClient->expects(self::never())->method('setSecret');
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder($wrapperClass)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        foreach ($metadata as $metaKey => $metaValue) {
+            $mockWrapper->setMetadataValue($metaKey, $metaValue);
+        }
+        $mockWrapper->expects(self::never())->method('getClient');
+        $mockWrapper->expects(self::exactly(2))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+    }
+
+    public function testRetrieveFromPrimaryVaultWhenTransVaultRetrievalFails(): void
+    {
+        $key = Key::createNewRandomKey();
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => [],
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::exactly(3))
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willThrowException(new ClientException('something failed', 500));
+        $mockTransClient->expects(self::never())->method('setSecret');
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder(GenericAKVWrapper::class)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::exactly(4))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+    }
+
+    private static function encode(mixed $data): string
+    {
+        return base64_encode((string) gzcompress(serialize($data)));
     }
 }

--- a/tests/Temporary/AKVWrappersWithTransClientTest.php
+++ b/tests/Temporary/AKVWrappersWithTransClientTest.php
@@ -466,6 +466,64 @@ class AKVWrappersWithTransClientTest extends TestCase
         ]));
     }
 
+    public function testSkipBackfillWhenTransStackIdEnvNotSet(): void
+    {
+        putenv('TRANS_ENCRYPTOR_STACK_ID=');
+
+        $key = Key::createNewRandomKey();
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willReturn(new SecretBundle([
+                'id' => 'secret-id',
+                'value' => self::encode([
+                    0 => [],
+                    1 => $key->saveToAsciiSafeString(),
+                ]),
+                'attributes' => [],
+            ]));
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('getSecret')
+            ->with('secret-name')
+            ->willThrowException(new ClientException('not found', 404));
+        $mockTransClient->expects(self::never())->method('setSecret');
+
+        $logger = new TestLogger();
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder(GenericAKVWrapper::class)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        $mockWrapper->logger = $logger;
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::exactly(2))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encryptedSecret = self::encode([
+            2 => Crypto::encrypt('something very secret', $key, true),
+            3 => 'secret-name',
+            4 => 'secret-version',
+        ]);
+
+        $secret = $mockWrapper->decrypt($encryptedSecret);
+
+        self::assertSame('something very secret', $secret);
+        self::assertTrue($logger->hasError('Env TRANS_ENCRYPTOR_STACK_ID not set.'));
+    }
+
     public function testObjectEncryptorFactoryInjectsLoggerInAKVWrappers(): void
     {
         $logger = new TestLogger();


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2410

If `GenericAKVWrapper::getTransClient()` returns an instance of `TransClient`:

1. Try to retrieve the secret from transient AKV
2. If it does not exist:
    - retrieve it from the primary AKV
    - update the key metadata item `stackId` to value from `TRANS_ENCRYPTOR_STACK_ID`
    - perform a backfill into the transient AKV