### PR TITLE
PST-2436: Ignore secret version when retrieving secrets from AKV

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build image
         run: |
           docker login --username "$DOCKERHUB_USER" --password "$DOCKERHUB_TOKEN"
-          docker-compose build
+          docker compose build
       - name: Run tests
         run: |          
-          docker-compose run ci
+          docker compose run ci

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,7 +4,7 @@ concurrency: ci
 
 env:
   TEST_TENANT_ID: 9b85ee6f-4fb0-4a46-8cb7-4dcc6b262a89
-  TEST_CLIENT_ID: 3a4162fa-43d4-4de7-a8c1-be3bc7765a8c
+  TEST_CLIENT_ID: bbd79ac8-74a2-4853-8c8c-99af4c614492
   TEST_CLIENT_SECRET: ${{ secrets.TEST_CLIENT_SECRET }}
   TEST_KEY_VAULT_URL: https://ci-object-encryptor.vault.azure.net/
   TEST_AWS_REGION: eu-central-1

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Prerequisites:
   * installed AWS CLI `aws` (and run `aws configure --profile YOUR_AWS_PROFILE_NAME`)
   * installed GCP CLI `gcloud` (and run `gcloud auth login` or `gcloud auth application-default login`)
 * installed `terraform` (https://www.terraform.io) and `jq` (https://stedolan.github.io/jq) to setup local env
-* installed `docker` and `docker-compose` to run & develop the app
+* installed `docker` to run & develop the app
 
 ```bash
 export NAME_PREFIX= # your name/nickname to make your resource unique & recognizable
@@ -88,7 +88,7 @@ terraform -chdir=./provisioning/local init -backend-config="key=object-encryptor
 terraform -chdir=./provisioning/local apply
 ./provisioning/local/update-env.sh aws # or azure or gcp
 
-docker-compose run --rm tests
+docker compose run --rm tests
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   # for development purposes
   tests: &tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,8 +1,10 @@
 parameters:
     level: max
-    checkMissingIterableValueType: false
     paths:
         - src
         - tests
+    ignoreErrors:
+        -
+            identifier: missingType.iterableValue
 includes:
     - vendor/phpstan/phpstan-phpunit/extension.neon

--- a/provisioning/ci/.terraform.lock.hcl
+++ b/provisioning/ci/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:Yi/V8LtJKyGZhKJmgsqKpVqBZKNECctHOn4fV3LFvOw=",
     "h1:x0gluX9ZKEmz+JJW3Ut5GgWDFOq/lhs2vkqJ+xt57zs=",
+    "h1:xXeHg5KDyH3rn2mrFh+iuvO2d9CEx8ryvOWRUMC3aWg=",
     "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
     "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
     "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
@@ -26,6 +27,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version     = "2.22.0"
   constraints = "~> 2.18"
   hashes = [
+    "h1:8AfMLW7SHmCPDODLKpx4QY0kNV4IZBrwDvfS/yAzpTI=",
     "h1:BLBnXLc5mCzSZ0PX5lGn5zgtnrkP7LMRwTA5pBwr2fk=",
     "h1:so17lrrqkdZcmQp5V/hvY5vLXw1BmwQMnlvGcRq/u0c=",
     "zh:062d84c514cd5015af60693ca4f3aece80d358fd7172951546eaba8093065c5b",
@@ -47,6 +49,7 @@ provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "2.99.0"
   constraints = "~> 2.98"
   hashes = [
+    "h1:/M8yLHqv0uOm9IbHRa4yZvQORr9ir1QyJyIyjGs4ryQ=",
     "h1:FXBB5TkvZpZA+ZRtofPvp5IHZpz4Atw7w9J8GDgMhvk=",
     "h1:Ith/+ax1KB67flRhGOP0+UxM8kEXOT950tGattoYvP4=",
     "h1:aCGPSDzEWQZLeWmUeSnXA6sDHMumbDqOVdSVKVziYoE=",
@@ -69,6 +72,7 @@ provider "registry.terraform.io/hashicorp/google" {
   constraints = "~> 4.74.0"
   hashes = [
     "h1:WazqiKdNsMSDEIyNBNT9rIY99jN2eWuiE6qMfKAZTpY=",
+    "h1:ghkjuvUrHsIlzjNL5KRsYZcP3R9BoFRfb0q069BXBi4=",
     "zh:60904193c367b1ba9a3cb1bd86ca469ffcec2f7237e59adf4b0a34c84b2fa9ff",
     "zh:6e5ac12f3fefc23907a94e5f6040118c978af76ab5deb60a5b80110c1c8ade09",
     "zh:9fc0ae0f97ab598c27fae0a6b19e82c13fd59d020d7cdfeeebdbe41c4a8216ef",

--- a/src/Wrapper/GenericAKVWrapper.php
+++ b/src/Wrapper/GenericAKVWrapper.php
@@ -150,10 +150,9 @@ class GenericAKVWrapper implements CryptoWrapperInterface
         }
         try {
             $decryptedContext = $this->getRetryProxy()->call(function () use ($encrypted) {
-                return $this->getClient()->getSecret(
-                    $encrypted[self::SECRET_NAME],
-                    $encrypted[self::SECRET_VERSION],
-                )->getValue();
+                return $this->getClient()
+                    ->getSecret($encrypted[self::SECRET_NAME])
+                    ->getValue();
             });
             assert(is_string($decryptedContext));
             $decryptedContext = $this->decode($decryptedContext);


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2436

Drop `SECRET_VERSION` as the 2nd arg in the `Client::getSecret()` call within `GenericAKVWrapper::decrypt()`, ensuring AKV always returns the latest version of the secret.