### PR TITLE
(csas-migration) PST-2411: Store in trans AKV during encrypt()

### DIFF
--- a/src/Wrapper/GenericAKVWrapper.php
+++ b/src/Wrapper/GenericAKVWrapper.php
@@ -141,19 +141,42 @@ class GenericAKVWrapper implements CryptoWrapperInterface
     public function encrypt(?string $data): string
     {
         $this->validateState();
+        $metadata = $this->metadata;
+
         try {
+            $client = $this->getClient();
+
+            // store secret in trans AKV if trans client is set
+            if ($this->getTransClient() !== null) {
+                if (!self::getTransStackId()) {
+                    // store in the default AKV as a fallback
+                    $this->logger?->error(sprintf('Env %s not set.', self::TRANS_STACK_ID_ENV));
+                } else {
+                    $client = $this->getTransClient();
+                    if (isset($metadata['stackId'])) {
+                        $metadata['stackId'] = self::getTransStackId();
+                    }
+                }
+            }
+
             $key = Key::createNewRandomKey();
             $context = $this->encode([
-                self::METADATA_INDEX => $this->metadata,
+                self::METADATA_INDEX => $metadata,
                 self::KEY_INDEX => $key->saveToAsciiSafeString(),
             ]);
-            $secret = $this->getRetryProxy()->call(function () use ($context) {
-                return $this->getClient()->setSecret(
+            $secret = $this->getRetryProxy()->call(function () use ($client, $context) {
+                return $client->setSecret(
                     new SetSecretRequest($context, new SecretAttributes()),
                     uniqid('gen-encryptor'),
                 );
             });
             /** @var SecretBundle $secret */
+            if ($client === $this->getTransClient()) {
+                $this->logger?->info('Secret "{secretName}" stored in {stackId} AKV.', [
+                    'secretName' => $secret->getName(),
+                    'stackId' => self::getTransStackId(),
+                ]);
+            }
             return $this->encode([
                 self::PAYLOAD_INDEX => Crypto::encrypt((string) $data, $key, true),
                 self::SECRET_NAME => $secret->getName(),

--- a/tests/Temporary/AKVWrappersWithTransClientTest.php
+++ b/tests/Temporary/AKVWrappersWithTransClientTest.php
@@ -551,8 +551,141 @@ class AKVWrappersWithTransClientTest extends TestCase
         }
     }
 
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testEncryptInTransVault(
+        string $wrapperClass,
+        array $metadata,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        putenv('TRANS_AZURE_KEY_VAULT_URL=https://vault-url');
+        putenv('TRANS_ENCRYPTOR_STACK_ID=trans-stack');
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::never())->method(self::anything());
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::once())
+            ->method('setSecret')
+            ->with(
+                self::callback(function ($arg) use ($metadata) {
+                    self::assertInstanceOf(SetSecretRequest::class, $arg);
+                    $decoded = (array) self::decode($arg->getArray()['value']);
+                    $decodedMetadata = (array) $decoded[0];
+                    self::assertTrue(
+                        (!array_key_exists('stackId', $metadata) && !array_key_exists('stackId', $decodedMetadata))
+                        || $decodedMetadata['stackId'] === 'trans-stack',
+                    );
+                    return true;
+                }),
+                self::stringStartsWith('gen-encryptor'),
+            )
+            ->willReturn(new SecretBundle([
+                'id' => 'https://test.vault.azure.net/secrets/secret-name/53af0dad94f248',
+                'value' => 'not-used',
+                'attributes' => [],
+            ]));
+
+        $logger = new TestLogger();
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder($wrapperClass)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        $mockWrapper->logger = $logger;
+        foreach ($metadata as $metaKey => $metaValue) {
+            $mockWrapper->setMetadataValue($metaKey, $metaValue);
+        }
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::atLeast(3))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encrypted = $mockWrapper->encrypt('My-V3ry-5ecret-P@ssword!');
+
+        self::assertMatchesRegularExpression('/^[A-Za-z0-9+\/=]+$/', $encrypted);
+        self::assertTrue($logger->hasInfo([
+            'message' => 'Secret "{secretName}" stored in {stackId} AKV.',
+            'context' => [
+                'secretName' => 'secret-name',
+                'stackId' => 'trans-stack',
+            ],
+        ]));
+    }
+
+    /**
+     * @dataProvider provideAKVWrappers
+     * @param class-string<GenericAKVWrapper> $wrapperClass
+     */
+    public function testEncryptFallbacksWithPrimaryVaultWhenTransStackIdEnvNotSet(
+        string $wrapperClass,
+        array $metadata,
+    ): void {
+        putenv('TRANS_AZURE_TENANT_ID=tenant-id');
+        putenv('TRANS_AZURE_CLIENT_ID=client-id');
+        putenv('TRANS_AZURE_CLIENT_SECRET=client-secret');
+        putenv('TRANS_AZURE_KEY_VAULT_URL=https://vault-url');
+
+        $mockClient = $this->createMock(Client::class);
+        $mockClient->expects(self::once())
+            ->method('setSecret')
+            ->with(
+                self::isInstanceOf(SetSecretRequest::class),
+                self::stringStartsWith('gen-encryptor'),
+            );
+
+        $mockTransClient = $this->createMock(TransClient::class);
+        $mockTransClient->expects(self::never())->method(self::anything());
+
+        $logger = new TestLogger();
+
+        /** @var GenericAKVWrapper|MockObject $mockWrapper */
+        $mockWrapper = $this->getMockBuilder($wrapperClass)
+            ->setConstructorArgs([
+                new EncryptorOptions(
+                    stackId: 'some-stack',
+                    akvUrl: 'some-url',
+                ),
+            ])
+            ->onlyMethods(['getClient', 'getTransClient'])
+            ->getMock();
+        $mockWrapper->logger = $logger;
+        foreach ($metadata as $metaKey => $metaValue) {
+            $mockWrapper->setMetadataValue($metaKey, $metaValue);
+        }
+        $mockWrapper->expects(self::once())
+            ->method('getClient')
+            ->willReturn($mockClient);
+        $mockWrapper->expects(self::exactly(2))
+            ->method('getTransClient')
+            ->willReturn($mockTransClient);
+
+        $encrypted = $mockWrapper->encrypt('My-V3ry-5ecret-P@ssword!');
+
+        self::assertMatchesRegularExpression('/^[A-Za-z0-9+\/=]+$/', $encrypted);
+        self::assertTrue($logger->hasError('Env TRANS_ENCRYPTOR_STACK_ID not set.'));
+        self::assertFalse($logger->hasInfo('Secret "{secretName}" stored in {stackId} AKV.'));
+    }
+
     private static function encode(mixed $data): string
     {
         return base64_encode((string) gzcompress(serialize($data)));
+    }
+
+    private static function decode(string $encoded): mixed
+    {
+        return @unserialize((string) gzuncompress((string) base64_decode($encoded)));
     }
 }


### PR DESCRIPTION
https://keboola.atlassian.net/browse/PST-2411

If `GenericAKVWrapper::getTransClient()` returns an instance of `TransClient`, perform the following in `encrypt()`:
1. update the key metadata item `stackId` to value from `TRANS_ENCRYPTOR_STACK_ID`
2. store secret in the transient AKV