### PR TITLE
Remove deprecated `psr/log` TestLogger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
     "require-dev": {
         "infection/infection": "^0.26",
         "keboola/coding-standard": "^15.0",
+        "monolog/monolog": "^3.9",
         "phpstan/phpstan": "^1.8",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
Replace deprecated `TestLogger` (removed from `psr/log`) with `TestHandler` + `Logger` from `monolog/monolog` repo